### PR TITLE
remove all objects of kind list as it's not supported by helm diff

### DIFF
--- a/openshift-projects/Chart.yaml
+++ b/openshift-projects/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Openshift Projects creation with own tiller instances
 name: openshift-projects
-version: 0.4.0
+version: 0.5.0

--- a/openshift-projects/templates/01_projects.yaml
+++ b/openshift-projects/templates/01_projects.yaml
@@ -1,20 +1,18 @@
 {{ $root := . }}
-apiVersion: v1
-items:
 {{- range $key, $value := .Values.projects }}
-- apiVersion: project.openshift.io/v1
-  kind: Project
-  metadata:
-    annotations:
+---
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  annotations:
 {{-   if $value.nodeSelector }}
-      openshift.io/node-selector: {{ $value.nodeSelector | quote }}
+    openshift.io/node-selector: {{ $value.nodeSelector | quote }}
 {{-   end }}
-      openshift.io/description: |
-{{ $value.description | indent 8 }}
-      openshift.io/display-name: {{ $key }}
-    labels:
-{{ include "common.labels.standard" $root | indent 6 }}
-    creationTimestamp: null
-    name: {{ $key }}
+    openshift.io/description: |
+{{ $value.description | indent 6 }}
+    openshift.io/display-name: {{ $key }}
+  labels:
+{{    include "common.labels.standard" $root | indent 4 }}
+  creationTimestamp: null
+  name: {{ $key }}
 {{- end }}
-kind: List

--- a/openshift-projects/templates/03_tillerSa.yaml
+++ b/openshift-projects/templates/03_tillerSa.yaml
@@ -1,15 +1,13 @@
 {{ $root := . }}
-apiVersion: v1
-items:
 {{- range $key, $value := .Values.projects }}
-  {{- if $value.deployTiller }}
-- apiVersion: v1
-  kind: ServiceAccount
-  metadata:
-    labels:
-{{ include "common.labels.standard" $root | indent 6 }}
-    name: "tiller-deploy"
-    namespace: {{ $key }}
-  {{- end }}
+{{-   if $value.deployTiller }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+{{      include "common.labels.standard" $root | indent 4 }}
+  name: "tiller-deploy"
+  namespace: {{ $key }}
+{{-   end }}
 {{- end }}
-kind: List

--- a/openshift-projects/templates/04_tillerRole.yaml
+++ b/openshift-projects/templates/04_tillerRole.yaml
@@ -1,20 +1,18 @@
 {{ $root := . }}
-apiVersion: v1
-items:
 {{- range $key, $value := .Values.projects }}
-  {{- if $value.deployTiller }}
-- kind: Role
-  apiVersion: authorization.openshift.io/v1
-  metadata:
-    labels:
-{{ include "common.labels.standard" $root | indent 6 }}
-    name: tiller-deploy
-    namespace: {{ $key }}
-  rules:
-  - apiGroups: ["*"]
-    resources: ["*"]
-    verbs: ["*"]
-  {{- end }}
+{{-   if $value.deployTiller }}
+---
+kind: Role
+apiVersion: authorization.openshift.io/v1
+metadata:
+  labels:
+{{      include "common.labels.standard" $root | indent 4 }}
+  name: tiller-deploy
+  namespace: {{ $key }}
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+{{-   end }}
 {{- end }}
-kind: List
 

--- a/openshift-projects/templates/05_tillerRoleBinding.yaml
+++ b/openshift-projects/templates/05_tillerRoleBinding.yaml
@@ -1,23 +1,20 @@
 {{ $root := . }}
-apiVersion: v1
-items:
 {{- range $key, $value := .Values.projects }}
-  {{- if $value.deployTiller }}
-- kind: RoleBinding
-  apiVersion: authorization.openshift.io/v1
-  metadata:
-    labels:
-{{ include "common.labels.standard" $root | indent 6 }}
-    name: tiller-deploy
-    namespace: {{ $key }}
-  roleRef:
-    name: tiller-deploy
-    namespace: {{ $key }}
-  subjects:
-  - kind: ServiceAccount
-    name: tiller-deploy
-    namespace: {{ $key }}
-  {{- end }}
+{{-   if $value.deployTiller }}
+---
+kind: RoleBinding
+apiVersion: authorization.openshift.io/v1
+metadata:
+  labels:
+{{      include "common.labels.standard" $root | indent 4 }}
+  name: tiller-deploy
+  namespace: {{ $key }}
+roleRef:
+  name: tiller-deploy
+  namespace: {{ $key }}
+subjects:
+- kind: ServiceAccount
+  name: tiller-deploy
+  namespace: {{ $key }}
+{{-   end }}
 {{- end }}
-kind: List
-

--- a/openshift-projects/templates/06_tillerDeloyment.yaml
+++ b/openshift-projects/templates/06_tillerDeloyment.yaml
@@ -1,51 +1,48 @@
 {{ $root := . }}
-apiVersion: v1
-items:
 {{- range $key, $value := .Values.projects }}
-  {{- if $value.deployTiller }}
-- kind: Deployment
-  apiVersion: extensions/v1beta1
-  metadata:
-    labels:
-{{ include "common.labels.standard" $root | indent 6 }}
-    name: tiller-deploy
-    namespace: {{ $key }}
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
+{{-   if $value.deployTiller }}
+---
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  labels:
+{{      include "common.labels.standard" $root | indent 4 }}
+  name: tiller-deploy
+  namespace: {{ $key }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: helm
+      name: tiller
+  template:
+    metadata:
+      labels:
         app: helm
         name: tiller
-    template:
-      metadata:
-        labels:
-          app: helm
-          name: tiller
-      spec:
-        containers:
+    spec:
+      containers:
+      - name: tiller-deploy
+        image: "{{ $root.Values.tiller.image }}:{{ $root.Values.tiller.tag }}"
+        env:
+        - name: TILLER_NAMESPACE
+          value: {{ $key }}
+        ports:
         - name: tiller-deploy
-          image: "{{ $root.Values.tiller.image }}:{{ $root.Values.tiller.tag }}"
-          env:
-          - name: TILLER_NAMESPACE
-            value: {{ $key }}
-          ports:
-          - name: tiller-deploy
-            containerPort: 44134
-          readinessProbe:
-            httpGet:
-              path: /readiness
-              port: 44135
-          livenessProbe:
-            httpGet:
-              path: /liveness
-              port: 44135
+          containerPort: 44134
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 44135
+        livenessProbe:
+          httpGet:
+            path: /liveness
+            port: 44135
 {{-     if $value.tillerLimits }}
-          resources:
-            limits:
-{{        toYaml $value.tillerLimits | indent 14 }}
+        resources:
+          limits:
+{{        toYaml $value.tillerLimits | indent 12 }}
 {{-     end }}
-        serviceAccountName: tiller-deploy
-  {{- end }}
+      serviceAccountName: tiller-deploy
+{{-   end }}
 {{- end }}
-kind: List
-

--- a/openshift-projects/templates/07_tillerService.yaml
+++ b/openshift-projects/templates/07_tillerService.yaml
@@ -1,32 +1,28 @@
 {{ $root := . }}
-apiVersion: v1
-items:
 {{- range $key, $value := .Values.projects }}
-  {{- if $value.deployTiller }}
-
-- kind: Service
-  apiVersion: v1 
-  metadata:
-    labels:
-{{ include "common.labels.standard" $root | indent 6 }}
-      app: helm
-      name: tiller
-    name: tiller-deploy
-    namespace: {{ $key }}
-  spec:
-    ports:
-    - name: tiller
-      port: 44134
-      protocol: TCP
-      targetPort: tiller
-    selector:
-      app: helm
-      name: tiller
-    sessionAffinity: None
-    type: ClusterIP
-  status:
-    loadBalancer: {}
-  {{- end }}
+{{-   if $value.deployTiller }}
+---
+kind: Service
+apiVersion: v1 
+metadata:
+  labels:
+{{      include "common.labels.standard" $root | indent 4 }}
+    app: helm
+    name: tiller
+  name: tiller-deploy
+  namespace: {{ $key }}
+spec:
+  ports:
+  - name: tiller
+    port: 44134
+    protocol: TCP
+    targetPort: tiller
+  selector:
+    app: helm
+    name: tiller
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}
+{{-   end }}
 {{- end }}
-kind: List
-

--- a/openshift-projects/templates/08_helmUserRole.yaml
+++ b/openshift-projects/templates/08_helmUserRole.yaml
@@ -1,29 +1,26 @@
 {{ $root := . }}
-apiVersion: v1
-items:
 {{- range $key, $value := .Values.projects }}
-  {{- if $value.helmAccess }}
-- kind: Role
-  apiVersion: authorization.openshift.io/v1
-  metadata:
-    labels:
-{{ include "common.labels.standard" $root | indent 6 }}
-    name: helm-user
-    namespace: {{ $key }}
-  rules:
-  - apiGroups:
-    - ""
-    resources:
-    - pods/portforward
-    verbs:
-    - create
-  - apiGroups:
-    - ""
-    resources:
-    - pods
-    verbs:
-    - list
-  {{- end }}
+{{-   if $value.helmAccess }}
+---
+kind: Role
+apiVersion: authorization.openshift.io/v1
+metadata:
+  labels:
+{{      include "common.labels.standard" $root | indent 4 }}
+  name: helm-user
+  namespace: {{ $key }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods/portforward
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+{{-   end }}
 {{- end }}
-kind: List
-

--- a/openshift-projects/templates/09_helmUserRoleBindings.yaml
+++ b/openshift-projects/templates/09_helmUserRoleBindings.yaml
@@ -1,23 +1,20 @@
 {{ $root := . }}
-apiVersion: v1
-items:
 {{- range $key, $value := .Values.projects }}
-  {{- range $helmAccess := $value.helmAccess }}
-- kind: RoleBinding
-  apiVersion: authorization.openshift.io/v1
-  metadata:
-    labels:
-{{ include "common.labels.standard" $root | indent 6 }}
-    name: helm-user-binding
-    namespace: {{ $key }}
-  roleRef:
-    name: helm-user
-    namespace: {{ $key }}
-  subjects:
-  - kind: ServiceAccount
-    name: {{ $helmAccess.ServiceAccountName }}
-    namespace: {{ $helmAccess.ServiceAccountNameSpace }}
-  {{- end }}
+{{-   range $helmAccess := $value.helmAccess }}
+---
+kind: RoleBinding
+apiVersion: authorization.openshift.io/v1
+metadata:
+  labels:
+{{      include "common.labels.standard" $root | indent 4 }}
+  name: helm-user-binding
+  namespace: {{ $key }}
+roleRef:
+  name: helm-user
+  namespace: {{ $key }}
+subjects:
+- kind: ServiceAccount
+  name: {{ $helmAccess.ServiceAccountName }}
+  namespace: {{ $helmAccess.ServiceAccountNameSpace }}
+{{-   end }}
 {{- end }}
-kind: List
-

--- a/openshift-projects/templates/10_editRoleBinding.yaml
+++ b/openshift-projects/templates/10_editRoleBinding.yaml
@@ -1,26 +1,23 @@
 {{ $root := . }}
-apiVersion: v1
-items:
 {{- range $key, $value := .Values.projects }}
-  {{- if $value.editAccess }}
-- kind: RoleBinding
-  apiVersion: authorization.openshift.io/v1
-  metadata:
-    labels:
-{{ include "common.labels.standard" $root | indent 6 }}
-    name: {{ $key }}-edit-binding
-    namespace: {{ $key }}
-  roleRef:
-    name: edit
-  subjects:
-    {{- range $editAccess := $value.editAccess }}
-  - kind: {{ $editAccess.kind }}
-    name: {{ $editAccess.name }}
-      {{- if $editAccess.namespace }}
-    namespace: {{ $editAccess.namespace }}
-      {{- end }}
-    {{- end }}
-  {{- end }}
+{{-   if $value.editAccess }}
+---
+kind: RoleBinding
+apiVersion: authorization.openshift.io/v1
+metadata:
+  labels:
+{{      include "common.labels.standard" $root | indent 4 }}
+  name: {{ $key }}-edit-binding
+  namespace: {{ $key }}
+roleRef:
+  name: edit
+subjects:
+{{-     range $editAccess := $value.editAccess }}
+- kind: {{ $editAccess.kind }}
+  name: {{ $editAccess.name }}
+{{-       if $editAccess.namespace }}
+  namespace: {{ $editAccess.namespace }}
+{{-       end }}
+{{-     end }}
+{{-   end }}
 {{- end }}
-kind: List
-

--- a/openshift-projects/templates/11_imagePullerRoleBindings.yaml
+++ b/openshift-projects/templates/11_imagePullerRoleBindings.yaml
@@ -1,22 +1,20 @@
 {{ $root := . }}
-apiVersion: v1
-items:
 {{- range $key, $value := .Values.projects }}
-  {{- if $value.imageAccess }}
-- kind: RoleBinding
-  apiVersion: authorization.openshift.io/v1
-  metadata:
-    labels:
-{{ include "common.labels.standard" $root | indent 6 }}
-    name: image-puller-binding
-    namespace: {{ $key }}
-  roleRef:
-    name: system:image-puller
-  subjects:
-    {{- range $imageAccess := $value.imageAccess }}
-  - kind: SystemGroup
-    name: system:serviceaccounts:{{ $imageAccess.NameSpace }}
-    {{- end}}
-  {{- end }}
+{{-   if $value.imageAccess }}
+---
+kind: RoleBinding
+apiVersion: authorization.openshift.io/v1
+metadata:
+  labels:
+{{      include "common.labels.standard" $root | indent 4 }}
+  name: image-puller-binding
+  namespace: {{ $key }}
+roleRef:
+  name: system:image-puller
+subjects:
+{{-     range $imageAccess := $value.imageAccess }}
+- kind: SystemGroup
+  name: system:serviceaccounts:{{ $imageAccess.NameSpace }}
+{{-     end}}
+{{-   end }}
 {{- end }}
-kind: List

--- a/openshift-projects/templates/12-resourcequota.yaml
+++ b/openshift-projects/templates/12-resourcequota.yaml
@@ -1,32 +1,31 @@
 {{ $root := . }}
-apiVersion: v1
-items:
 {{- range $key, $value := .Values.projects }}
 {{-   if $value.quotas }}
-- kind: ResourceQuota
-  apiVersion: v1
-  metadata:
-    labels:
-{{      include "common.labels.standard" $root | indent 6 }}
-    name: project-quotas
-    namespace: {{ $key }}
-  spec:
-    hard:
-{{      toYaml $value.quotas | indent 6 }}
+---
+kind: ResourceQuota
+apiVersion: v1
+metadata:
+  labels:
+{{      include "common.labels.standard" $root | indent 4 }}
+  name: project-quotas
+  namespace: {{ $key }}
+spec:
+  hard:
+{{      toYaml $value.quotas | indent 4 }}
 {{-   end }}
 {{-   if $value.disableBestEffort }}
-- kind: ResourceQuota
-  apiVersion: v1
-  metadata:
-    labels:
-{{      include "common.labels.standard" $root | indent 6 }}
-    name: disable-best-effort
-    namespace: {{ $key }}
-  spec:
-    hard:
-      pods: {{ if $value.deployTiller }}"1"{{ else }}"0"{{ end }}
-    scopes:
-    - BestEffort
+---
+kind: ResourceQuota
+apiVersion: v1
+metadata:
+  labels:
+{{      include "common.labels.standard" $root | indent 4 }}
+  name: disable-best-effort
+  namespace: {{ $key }}
+spec:
+  hard:
+    pods: {{ if $value.deployTiller }}"1"{{ else }}"0"{{ end }}
+  scopes:
+  - BestEffort
 {{-   end }}
 {{- end }}
-kind: List

--- a/openshift-projects/templates/20_anyUidUserSa.yaml
+++ b/openshift-projects/templates/20_anyUidUserSa.yaml
@@ -1,15 +1,13 @@
 {{ $root := . }}
-apiVersion: v1
-items:
 {{- range $key, $value := .Values.projects }}
-  {{- if $value.deployAnyUidServiceAccount }}
-- apiVersion: v1
-  kind: ServiceAccount
-  metadata:
-    labels:
-{{ include "common.labels.standard" $root | indent 6 }}
-    name: {{ $root.Values.anyUid.ServiceAccountName }}
-    namespace: {{ $key }}
-  {{- end }}
+{{-   if $value.deployAnyUidServiceAccount }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+{{      include "common.labels.standard" $root | indent 4 }}
+  name: {{ $root.Values.anyUid.ServiceAccountName }}
+  namespace: {{ $key }}
+{{-   end }}
 {{- end }}
-kind: List

--- a/openshift-projects/templates/21_anyUidUserScc.yaml
+++ b/openshift-projects/templates/21_anyUidUserScc.yaml
@@ -4,7 +4,7 @@ apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
   labels:
-{{ include "common.labels.standard" . | indent 6 }}
+{{    include "common.labels.standard" . | indent 6 }}
   name: project-anyuid
 priority: 10
 allowHostDirVolumePlugin: false
@@ -29,9 +29,9 @@ seLinuxContext:
 supplementalGroups:
   type: RunAsAny
 users:
-{{- range $key, $value := .Values.projects }}
+{{-   range $key, $value := .Values.projects }}
 - system:serviceaccount:{{ $key }}:{{ $root.Values.anyUid.ServiceAccountName }}
-{{- end }}
+{{-   end }}
 volumes:
 - configMap
 - downwardAPI

--- a/openshift-projects/values.yaml
+++ b/openshift-projects/values.yaml
@@ -94,7 +94,7 @@ projects: {}
 # Set the image, version tag and tiller user service account name for tiller
 tiller:
   image: gcr.io/kubernetes-helm/tiller
-  tag: v2.10.0
+  tag: v2.11.0
 
 # Set the SA used for the anyUid scc
 anyUid:


### PR DESCRIPTION
With usage of objects of kind list, 2 or more empty lists will produce an error on a helm diff.

As we use helm diff a lot, the chart will be refactored to remove all lists objects.

Below an error output:

Comparing project-test c2c/openshift-projects
2019/01/31 09:01:54 Error: Found duplicate key "tiller, , List (v1)" in manifest
2019/01/31 09:01:54 Error: Found duplicate key "tiller, , List (v1)" in manifest
2019/01/31 09:01:54 Error: Found duplicate key "tiller, , List (v1)" in manifest
2019/01/31 09:01:54 Error: Found duplicate key "tiller, , List (v1)" in manifest
2019/01/31 09:01:54 Error: Found duplicate key "tiller, , List (v1)" in manifest
2019/01/31 09:01:54 Error: Found duplicate key "tiller, , List (v1)" in manifest
2019/01/31 09:01:54 Error: Found duplicate key "tiller, , List (v1)" in manifest
2019/01/31 09:01:54 Error: Found duplicate key "tiller, , List (v1)" in manifest
2019/01/31 09:01:54 Error: Found duplicate key "tiller, , List (v1)" in manifest
2019/01/31 09:01:54 Error: Found duplicate key "tiller, , List (v1)" in manifest
2019/01/31 09:01:54 Error: Found duplicate key "tiller, , List (v1)" in manifest
2019/01/31 09:01:54 Error: Found duplicate key "tiller, , List (v1)" in manifest
2019/01/31 09:01:54 Error: Found duplicate key "tiller, , List (v1)" in manifest
2019/01/31 09:01:54 Error: Found duplicate key "tiller, , List (v1)" in manifest
2019/01/31 09:01:54 Error: Found duplicate key "tiller, , List (v1)" in manifest
2019/01/31 09:01:54 Error: Found duplicate key "tiller, , List (v1)" in manifest
2019/01/31 09:01:54 Error: Found duplicate key "tiller, , List (v1)" in manifest
2019/01/31 09:01:54 Error: Found duplicate key "tiller, , List (v1)" in manifest
2019/01/31 09:01:54 Error: Found duplicate key "tiller, , List (v1)" in manifest
2019/01/31 09:01:54 Error: Found duplicate key "tiller, , List (v1)" in manifest