### PR TITLE
Public name settings not needed for puppetdb exporter

### DIFF
--- a/puppetdb/Chart.yaml
+++ b/puppetdb/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "5.2.7"
 description: A Helm chart for PuppetDB
 name: puppetdb
-version: 0.7.0
+version: 0.7.1

--- a/puppetdb/templates/prometheus-puppetdb-exporter-deployment.yaml
+++ b/puppetdb/templates/prometheus-puppetdb-exporter-deployment.yaml
@@ -25,7 +25,7 @@ spec:
           image: "docker.io/puppet/puppet-agent:5.5.1"
           command: ["sh", "-c"]
           args:
-            - "psk=$(cat /run/secrets/autosign_psk); hostname=$(puppet config print certname | tr -d '\n'); echo \"custom_attributes:\n  1.2.840.113549.1.9.7: 'hashed;$(echo -n $psk/$hostname/puppetdb/production | openssl dgst -binary -sha256 | openssl base64)'\nextension_requests:\n  pp_role: 'puppetdb'\n  pp_environment: 'production'\" > /etc/puppetlabs/puppet/csr_attributes.yaml; puppet agent -t --noop --environment production --server puppetserver --dns_alt_names='{{ include "puppetdb.fullname" . }},{{ .Values.public_name }}' --waitforcert 60 --confdir /etc/puppetlabs/puppet; cd /etc/puppetlabs/puppet/ssl && cp private_keys/$hostname.pem private_keys/prometheus-puppetdb-exporter.pem && cp certs/$hostname.pem certs/prometheus-puppetdb-exporter.pem ; mv /etc/puppetlabs/puppet/ssl/* /srv/puppetssl/"
+            - "psk=$(cat /run/secrets/autosign_psk); hostname=$(puppet config print certname | tr -d '\n'); echo \"custom_attributes:\n  1.2.840.113549.1.9.7: 'hashed;$(echo -n $psk/$hostname/puppetdb/production | openssl dgst -binary -sha256 | openssl base64)'\nextension_requests:\n  pp_role: 'puppetdb'\n  pp_environment: 'production'\" > /etc/puppetlabs/puppet/csr_attributes.yaml; puppet agent -t --noop --environment production --server puppetserver --waitforcert 60 --confdir /etc/puppetlabs/puppet; cd /etc/puppetlabs/puppet/ssl && cp private_keys/$hostname.pem private_keys/prometheus-puppetdb-exporter.pem && cp certs/$hostname.pem certs/prometheus-puppetdb-exporter.pem ; mv /etc/puppetlabs/puppet/ssl/* /srv/puppetssl/"
           env:
             - name: HOME
               value: /tmp

--- a/puppetdb/templates/puppetdb-deployment.yaml
+++ b/puppetdb/templates/puppetdb-deployment.yaml
@@ -24,7 +24,7 @@ spec:
           image: "docker.io/puppet/puppet-agent:5.5.1"
           command: ["sh", "-c"]
           args:
-            - "psk=$(cat /run/secrets/autosign_psk); hostname=$(puppet config print certname | tr -d '\n'); echo \"custom_attributes:\n  1.2.840.113549.1.9.7: 'hashed;$(echo -n $psk/$hostname/puppetdb/production | openssl dgst -binary -sha256 | openssl base64)'\nextension_requests:\n  pp_role: 'puppetdb'\n  pp_environment: 'production'\" > /etc/puppetlabs/puppet/csr_attributes.yaml; puppet agent -t --noop --environment production --server puppetserver --dns_alt_names='{{ include "puppetdb.fullname" . }},{{ .Values.public_name }}' --waitforcert 60 --confdir /etc/puppetlabs/puppet; cd /etc/puppetlabs/puppet/ssl && cp private_keys/$hostname.pem private_keys/puppetdb.pem && cp certs/$hostname.pem certs/puppetdb.pem ; mv /etc/puppetlabs/puppet/ssl/* /srv/puppetssl/"
+            - "psk=$(cat /run/secrets/autosign_psk); hostname=$(puppet config print certname | tr -d '\n'); echo \"custom_attributes:\n  1.2.840.113549.1.9.7: 'hashed;$(echo -n $psk/$hostname/puppetdb/production | openssl dgst -binary -sha256 | openssl base64)'\nextension_requests:\n  pp_role: 'puppetdb'\n  pp_environment: 'production'\" > /etc/puppetlabs/puppet/csr_attributes.yaml; puppet agent -t --noop --environment production --server puppetserver --dns_alt_names='{{ include "puppetdb.fullname" . }},{{ .Values.puppetdb.public_name }}' --waitforcert 60 --confdir /etc/puppetlabs/puppet; cd /etc/puppetlabs/puppet/ssl && cp private_keys/$hostname.pem private_keys/puppetdb.pem && cp certs/$hostname.pem certs/puppetdb.pem ; mv /etc/puppetlabs/puppet/ssl/* /srv/puppetssl/"
           env:
             - name: HOME
               value: /tmp

--- a/puppetdb/values.yaml
+++ b/puppetdb/values.yaml
@@ -5,7 +5,6 @@
 autosign:
   psk: ''
 
-public_name: ''
 
 
 puppetdb:
@@ -54,6 +53,8 @@ puppetdb:
   tolerations: []
 
   affinity: {}
+
+  public_name: ''
 
   java_mem_limit: "256m"
 


### PR DESCRIPTION
The public_name settings is useless for the prometheus-puppetdb-exporter deployment. Move it under puppetdb tree.