### PR TITLE
Add jvm args to exit on out of memory

### DIFF
--- a/puppetdb/Chart.yaml
+++ b/puppetdb/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "5.2.7"
 description: A Helm chart for PuppetDB
 name: puppetdb
-version: 0.7.1
+version: 0.7.2

--- a/puppetdb/templates/puppetdb-deployment.yaml
+++ b/puppetdb/templates/puppetdb-deployment.yaml
@@ -47,7 +47,7 @@ spec:
           image: "{{ .Values.puppetdb.image.repository }}:{{ .Values.puppetdb.image.tag }}"
           imagePullPolicy: {{ .Values.puppetdb.image.pullPolicy }}
           command: [ "java" ]
-          args: [ "-Djava.net.preferIPv4Stack=true", "-Xms{{ .Values.puppetdb.java_mem_limit }}", "-Xmx{{ .Values.puppetdb.java_mem_limit }}",
+          args: [ "-Djava.net.preferIPv4Stack=true", "-Xms{{ .Values.puppetdb.java_mem_limit }}", "-Xmx{{ .Values.puppetdb.java_mem_limit }}", "-XX:+ExitOnOutOfMemoryError",
             "-javaagent:/jmx-exporter/jmx_prometheus_javaagent-0.12.0.jar=9080:/jmx-exporter/config.yaml",
             "-cp", "/puppetdb.jar", "clojure.main",
             "-m", "puppetlabs.puppetdb.core", "services", "-c",


### PR DESCRIPTION
Add the jvm option ExitOnOutOfMemoryError to exit the jvm on the first occurence of an out of memory