### PR TITLE
Fix some interpretatio issues due to yaml being "smart"

### DIFF
--- a/varnish/values.yaml
+++ b/varnish/values.yaml
@@ -97,7 +97,7 @@ varnishKafkaLogLevel: 6
 ## kafka is slow, or in case of peak in log rate, the messages overflowing this
 ## buffer will not be read from varnish shared buffer, thus the ring buffer
 ## might overflow.
-varnishKafkaBufferedMessages: 1000000
+varnishKafkaBufferedMessages: '1000000'
 
 # Configuration of the collectd Varnish plugin.
 collectdVarnish:
@@ -123,7 +123,7 @@ collectdVarnish:
 varnishKafkaSendMaxRetries: 3
 
 ## Message timeout for sending to kafka milliseconds
-varnishKafkaTimeout: 60000
+varnishKafkaTimeout: '60000'
 
 ## The name of the kafka topic to send logs to, required if output is kafka.
 varnishKafkaTopic: varnish


### PR DESCRIPTION
Big round numbers are converted to scientific notation by YAML, because "this is the smart thing to do" and "nobody cares about the difference"... except that librdkafka cares...

1000000 becomes 1e+06, and when librdkafka parses 1e+06, it reads the integer 1.

A buffer of size 1 (number of message) is a bit small when you are storing varnish http log while sending then to kafka. This causes message loss because the buffer is full.