### PR TITLE
feat(terraboard): add support for additional envs and custom yaml config

### DIFF
--- a/terraboard/Chart.yaml
+++ b/terraboard/Chart.yaml
@@ -2,7 +2,7 @@ name: terraboard
 home: https://github.com/camptocamp/terraboard
 icon: https://raw.githubusercontent.com/camptocamp/terraboard/master/logo/terraboard_logo_only.png
 version: 2.0.3
-appVersion: "2.0.0"
+appVersion: "2.1.1"
 apiVersion: v1
 description: A web interface for Terraform states
 keywords:

--- a/terraboard/Chart.yaml
+++ b/terraboard/Chart.yaml
@@ -1,7 +1,7 @@
 name: terraboard
 home: https://github.com/camptocamp/terraboard
 icon: https://raw.githubusercontent.com/camptocamp/terraboard/master/logo/terraboard_logo_only.png
-version: 2.0.3
+version: 2.1.0
 appVersion: "2.1.1"
 apiVersion: v1
 description: A web interface for Terraform states

--- a/terraboard/templates/configmap.yaml
+++ b/terraboard/templates/configmap.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.additionalYamlConfig }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "terraboard.fullname" . }}-configmap
+  labels:
+{{ include "terraboard.labels" . | indent 4 }}
+data:
+  config.yaml: {{ .Values.additionalYamlConfig | indent 4 }}
+{{- end }}

--- a/terraboard/templates/configmap.yaml
+++ b/terraboard/templates/configmap.yaml
@@ -7,5 +7,6 @@ metadata:
   labels:
 {{ include "terraboard.labels" . | indent 4 }}
 data:
-  config.yaml: {{ .Values.additionalYamlConfig | indent 4 }}
+  config.yaml: |
+{{ .Values.additionalYamlConfig | toYaml | indent 4 }}
 {{- end }}

--- a/terraboard/templates/deployment.yaml
+++ b/terraboard/templates/deployment.yaml
@@ -32,6 +32,11 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.additionalYamlConfig }}
+          volumeMounts:
+            - name: custom-config-yaml
+              mountPath: /config
+          {{- end }}
           ports:
             - name: http
               containerPort: 8080
@@ -40,6 +45,10 @@ spec:
               containerPort: 8081
               protocol: TCP
           env:
+            {{- if .Values.additionalYamlConfig }}
+            - name: CONFIG_FILE
+              value: /config/config.yaml
+            {{- end }}
             - name: TERRABOARD_BASE_URL
               value: {{ .Values.terraboard.base_url }}
             - name: TERRABOARD_PORT
@@ -80,6 +89,11 @@ spec:
               value: {{ .Values.aws.dynamodb_table }}
             - name: AWS_FILE_EXTENSION
               value: {{ .Values.aws.file_extension }}
+
+            {{- with .Values.additionalEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+
 #          livenessProbe:
 #            httpGet:
 #              path: /
@@ -91,6 +105,14 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
+      {{- if .Values.additionalYamlConfig }}
+        - name: custom-config-yaml
+          configMap:
+            name: {{ include "terraboard.fullname" . }}-configmap
+            items:
+            - key: config.yaml
+              path: config.yaml
+      {{- end }}
 {{- if .Values.volumes }}
 {{ toYaml .Values.volumes | indent 8 }}
 {{- end }}

--- a/terraboard/values.yaml
+++ b/terraboard/values.yaml
@@ -36,7 +36,7 @@ additionalEnv: []
 # Allow configuration of multiples providers which env/flags config doesn't support
 # Check the github readme for more details about YAML configuration: https://github.com/camptocamp/terraboard#available-parameters
 
-# additionalYamlConfig: |-
+# additionalYamlConfig:
 #   provider:
 #     no-locks: true
 #     no-versioning: true

--- a/terraboard/values.yaml
+++ b/terraboard/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: docker.io/camptocamp/terraboard
-  tag: 2.0.0
+  tag: 2.1.1
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -19,6 +19,44 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
+
+# Specify additional environment variables to be set in the container.
+# For example:
+# - name: FOO
+#   value: ""
+# - name: BAR
+#   valueFrom:
+#     secretKeyRef:
+#       name: SECRET_NAME
+#       key: BAR
+additionalEnv: []
+
+# Specify additional yaml config for Terraboard following the configuration scheme
+# defined in the github repo
+# Allow configuration of multiples providers which env/flags config doesn't support
+# Check the github readme for more details about YAML configuration: https://github.com/camptocamp/terraboard#available-parameters
+
+# additionalYamlConfig: |-
+#   provider:
+#     no-locks: true
+#     no-versioning: true
+#
+#   aws:
+#     - endpoint: http://minio:9000/
+#       region: eu-west-1
+#       s3:
+#         - bucket: test-bucket
+#           force-path-style: true
+#           file-extension: 
+#             - .tfstate
+#
+#     - endpoint: http://minio:9000/
+#       region: eu-west-1
+#       s3:
+#         - bucket: test-bucket2
+#           force-path-style: true
+#           file-extension: 
+#             - .tfstate
 
 podSecurityContext: {}
   # fsGroup: 2000


### PR DESCRIPTION
Allow users to set custom yaml config file to configure Terraboard and to add additional env variables which aren't handled by the chart itself.
Also bump terraboard image version to 2.1.1

Fix issue #47