### PR TITLE
feat(S3 Exporter) - Enhance the chart by adding values and change the enable/disable

### DIFF
--- a/s3-exporter/templates/grafana-dashboard-cm.yaml
+++ b/s3-exporter/templates/grafana-dashboard-cm.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.dashboards.enabled | default true }}
+{{ if .Values.dashboards.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/s3-exporter/templates/prometheusrules.yaml
+++ b/s3-exporter/templates/prometheusrules.yaml
@@ -1,9 +1,13 @@
+{{ if .Values.prometheusrules.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ template "s3-exporter.fullname" . }}
   labels:
     {{- include "s3-exporter.selectorLabels" . | nindent 8 }}
+    {{- if .Values.prometheusrules.additionalLabels }}
+    {{ toYaml .Values.prometheusrules.additionalLabels | nindent 4 }}
+    {{- end }}
 spec:
   groups:
   - name: {{ template "s3-exporter.fullname" . }}-{{ .Release.Namespace }}
@@ -26,4 +30,5 @@ spec:
           {{- toYaml .Values.prometheusrules.labels | nindent 10 }}
         annotations:
           description: Cannot find any metric for the backup S3 bucket
-          summary: Cannot find any metric for the backup S3 bucke
+          summary: Cannot find any metric for the backup S3 bucket
+{{ end }}

--- a/s3-exporter/templates/servicemonitor.yaml
+++ b/s3-exporter/templates/servicemonitor.yaml
@@ -3,6 +3,11 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "s3-exporter.fullname" . }}
+  labels:
+    {{- include "s3-exporter.selectorLabels" . | nindent 8 }}
+    {{- if .Values.servicemonitor.additionalLabels }}
+    {{ toYaml .Values.servicemonitor.additionalLabels | nindent 4 }}
+    {{- end }}
 spec:
   endpoints:
   - port: http

--- a/s3-exporter/values.yaml
+++ b/s3-exporter/values.yaml
@@ -42,12 +42,18 @@ serviceAccount:
 
 servicemonitor:
   enabled: false
+  additionalLabels: {}
+  #  release: kube-prometheus-stack
+  targetLabels: {}
 
 prometheusrules:
+  enabled: true
   oldestfiledays: 7
   labels:
     severity: "warning"
     line: "prod"
+  additionalLabels: {}
+  #  release: kube-prometheus-stack
 
 s3:
   accessKey: "S3-ACCESS-KEY"
@@ -72,7 +78,7 @@ imagePullSecrets: []
 
 # Inject the dashboard for this exporter
 dashboards:
-  enabled: false
+  enabled: true
   job: s3-exporter # The name of the job label in the prometheus metric
 #  namespace: app Which namesapce the probes are deployed
 


### PR DESCRIPTION
In this PR contains the following items:

1. Adding additional Lables to prometheusRule and ServiceMonitor to be able to add extra labels such as `release: kube-promethues-stack` to be monitored by `kube-prometheus-stack`
2. Possibility to enable and disable prometheusRule
3. Remove `default true` from Grafana Dashboard Configmap to check the values from values.yaml and not be forced to be true.