### PR TITLE
chore: update servicemonitor and s3 secret

### DIFF
--- a/s3-exporter/Chart.yaml
+++ b/s3-exporter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes to export metrics about files stored in a s3 bucket
 name: s3-exporter
-version: 2.1.0
+version: 2.2.0
 home: https://github.com/camptocamp/charts/s3-exporter

--- a/s3-exporter/templates/_helpers.tpl
+++ b/s3-exporter/templates/_helpers.tpl
@@ -25,18 +25,6 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
-The name of the secret used to store the SecretKey and AccessKey to access the bucket.
-It is the fullname of the release if .Values.s3.secretName is not set.
-*/}}
-{{- define "s3-exporter.bucketAccessSecretName" -}}
-{{- if .Values.s3.secretName }}
-{{- .Values.s3.secretName }}
-{{- else }}
-{{- include "s3-exporter.fullname" . }}
-{{- end }}
-{{- end }}
-
-{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "s3-exporter.chart" -}}

--- a/s3-exporter/templates/deployment.yaml
+++ b/s3-exporter/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
           {{- end }}
           envFrom:
           - secretRef:
-              name: {{ template "s3-exporter.bucketAccessSecretName" . }}
+              name: {{ .Values.s3.existingSecret | default (include "s3-exporter.fullname" .) }}
           ports:
             - name: exporter
               containerPort: 9340

--- a/s3-exporter/templates/prometheusrules.yaml
+++ b/s3-exporter/templates/prometheusrules.yaml
@@ -1,9 +1,10 @@
+{{- if .Values.prometheusrules.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ template "s3-exporter.fullname" . }}
   labels:
-    {{- include "s3-exporter.selectorLabels" . | nindent 8 }}
+    {{- include "s3-exporter.selectorLabels" . | nindent 4 }}
 spec:
   groups:
   - name: {{ template "s3-exporter.fullname" . }}-{{ .Release.Namespace }}
@@ -27,3 +28,4 @@ spec:
         annotations:
           description: Cannot find any metric for the backup S3 bucket
           summary: Cannot find any metric for the backup S3 bucke
+{{- end }}

--- a/s3-exporter/templates/s3-accesskey.yaml
+++ b/s3-exporter/templates/s3-accesskey.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "s3-exporter.bucketAccessSecretName" . }}
+  name: {{ include "s3-exporter.fullname" . }}
 type: Opaque
 data:
   AWS_ACCESS_KEY_ID: {{ .Values.s3.accessKey | b64enc }}

--- a/s3-exporter/templates/service.yaml
+++ b/s3-exporter/templates/service.yaml
@@ -4,9 +4,6 @@ metadata:
   name: {{ include "s3-exporter.fullname" . }}
   labels:
     {{- include "s3-exporter.labels" . | nindent 4 }}
-    {{- if .Values.extraLabels }}
-    {{- toYaml .Values.extraLabels | nindent 4 }}
-    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/s3-exporter/templates/servicemonitor.yaml
+++ b/s3-exporter/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.servicemonitor.enabled }}
+{{- if .Values.servicemonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -6,7 +6,7 @@ metadata:
 spec:
   endpoints:
   - port: http
-    path: /metrics
+    path: /probe
     params:
       bucket:
         - {{ .Values.s3.bucket }}
@@ -15,10 +15,6 @@ spec:
     - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      {{- include "s3-exporter.selectorLabels" . | nindent 6 }}
-  {{ with .Values.servicemonitor.targetLabels }}
-  targetLabels:
-    {{- toYaml . | nindent 4 }}
-  {{ end }}
-{{ end }}
+      {{- include "s3-exporter.labels" . | nindent 6 }}
+{{- end }}
 

--- a/s3-exporter/values.yaml
+++ b/s3-exporter/values.yaml
@@ -41,9 +41,10 @@ serviceAccount:
   create: false
 
 servicemonitor:
-  enabled: false
+  enabled: true
 
 prometheusrules:
+  enabled: true
   oldestfiledays: 7
   labels:
     severity: "warning"
@@ -53,16 +54,15 @@ s3:
   accessKey: "S3-ACCESS-KEY"
   secretKey: "S3-SECRET-KEY"
   region: "us-east-1"
-  # If set allows to select the name of the secret used for the AccessKey and SecretKey.
-  # The default value is the release fullname.
-  secretName:
 
+  # The name of the existing secret
   # This will disable the creation of a secret in this chart and use an existing one.
   # The secret must contain these keys:
   #  - AWS_ACCESS_KEY_ID
   #  - AWS_SECRET_ACCESS_KEY
   # Optionnally any other environment variable taken by the s3-exporter.
-  existingSecret: false
+  existingSecret: ""
+
   # Bucket to use iun servicemonitor, only used if servicemonitor is enabled
   bucket: ""
 


### PR DESCRIPTION
This PR:

- removes s3-exporter.bucketAccessSecretName, using the fullname as the S3 secret instead.
- makes the deployment use existingSecret if defined; otherwise, it falls back to the S3 secret created by the chart.
- makes PrometheusRule creation optional.
- updates the ServiceMonitor’s matchLabels selector.
